### PR TITLE
Replace Elasticsearch with AxonOps OpenSearch (axondb-search)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cassandra: ["4.0", "4.1", "5.0"]
+        cassandra: ["5.0"]
     env:
       CASSANDRA_VERSION: ${{ matrix.cassandra }}
       COMPOSE_PROJECT_NAME: axonops-ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,118 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  smoke-test:
+    name: docker compose smoke test (Cassandra ${{ matrix.cassandra }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        cassandra: ["4.0", "4.1", "5.0"]
+    env:
+      CASSANDRA_VERSION: ${{ matrix.cassandra }}
+      COMPOSE_PROJECT_NAME: axonops-ci
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate docker-compose.yml
+        run: docker compose config --quiet
+
+      - name: Pull images
+        run: docker compose pull --quiet
+
+      - name: Start core stack (search + server + dash)
+        run: docker compose up -d axondb-search axon-server axon-dash
+
+      - name: Wait for core services to become healthy
+        run: |
+          set -euo pipefail
+          for svc in axondb-search axon-server axon-dash; do
+            echo "::group::Waiting for $svc"
+            for i in $(seq 1 60); do
+              status=$(docker inspect --format='{{.State.Health.Status}}' "$(docker compose ps -q "$svc")" 2>/dev/null || echo "unknown")
+              echo "[$i] $svc: $status"
+              if [ "$status" = "healthy" ]; then break; fi
+              if [ "$status" = "unhealthy" ]; then
+                echo "::error::$svc became unhealthy"
+                docker compose logs "$svc" | tail -100
+                exit 1
+              fi
+              sleep 5
+            done
+            if [ "$status" != "healthy" ]; then
+              echo "::error::$svc did not become healthy in time"
+              docker compose logs "$svc" | tail -100
+              exit 1
+            fi
+            echo "::endgroup::"
+          done
+
+      - name: Verify OpenSearch is reachable with TLS + auth
+        run: |
+          docker compose exec -T axondb-search \
+            curl -sSf -k -u admin:'MyS3cur3P@ss2025' \
+            https://127.0.0.1:9200/_cluster/health | tee /tmp/health.json
+          grep -q '"status":"\(green\|yellow\)"' /tmp/health.json
+
+      - name: Verify axon-server connected to search backend
+        run: |
+          if docker compose logs axon-server 2>&1 | grep -iE 'search.*(error|fail|refused)'; then
+            echo "::error::axon-server reports search backend errors"
+            docker compose logs axon-server | tail -100
+            exit 1
+          fi
+
+      - name: Verify axon-dash HTTP responds
+        run: curl -sSf --retry 10 --retry-delay 3 http://localhost:3000/ -o /dev/null
+
+      - name: Start full stack (Cassandra nodes)
+        run: docker compose up -d
+
+      - name: Wait for Cassandra nodes to become healthy
+        run: |
+          set -euo pipefail
+          for svc in cassandra-0 cassandra-1 cassandra-2; do
+            echo "::group::Waiting for $svc"
+            for i in $(seq 1 90); do
+              status=$(docker inspect --format='{{.State.Health.Status}}' "$(docker compose ps -q "$svc")" 2>/dev/null || echo "unknown")
+              echo "[$i] $svc: $status"
+              if [ "$status" = "healthy" ]; then break; fi
+              sleep 5
+            done
+            if [ "$status" != "healthy" ]; then
+              echo "::error::$svc did not become healthy"
+              docker compose logs "$svc" | tail -100
+              exit 1
+            fi
+            echo "::endgroup::"
+          done
+
+      - name: Verify Cassandra cluster has 3 nodes UN
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 30); do
+            up=$(docker compose exec -T cassandra-0 nodetool status 2>/dev/null | awk '/^UN/{c++} END{print c+0}')
+            echo "[$i] UN nodes: $up"
+            if [ "$up" -eq 3 ]; then exit 0; fi
+            sleep 10
+          done
+          echo "::error::Did not observe 3 UN nodes"
+          docker compose exec -T cassandra-0 nodetool status || true
+          exit 1
+
+      - name: Dump container status on failure
+        if: failure()
+        run: |
+          docker compose ps
+          docker compose logs --tail=200
+
+      - name: Tear down
+        if: always()
+        run: docker compose down -v --remove-orphans

--- a/README.md
+++ b/README.md
@@ -1,7 +1,18 @@
+<p align="center">
+  <a href="https://axonops.com">
+    <img src="https://digitalis-marketplace-assets.s3.us-east-1.amazonaws.com/AxonopsDigitalMaster_AxonopsFullLogoBlue.jpg" alt="AxonOps" width="300">
+  </a>
+</p>
+
+<p align="center">
+  <em>Built and maintained by <a href="https://axonops.com">AxonOps</a></em>
+</p>
+
 # AxonOps Cassandra Development Cluster
 
 This Docker Compose file will create a Cassandra cluster containing 3 nodes along with AxonOps for
-cluster monitoring and management.
+cluster monitoring and management. The stack uses AxonOps-built containers throughout, including
+`axondb-search` (OpenSearch 3.3.2) as the search backend.
 
 ## One-click deploy to AWS
 
@@ -99,3 +110,41 @@ docker compose up -d
 ```
 
 The supported values for `CASSANDRA_VERSION` are `5.0`, `4.1` or `4.0`.
+
+## Search backend (axondb-search / OpenSearch)
+
+The `axondb-search` service uses the AxonOps-built OpenSearch image
+(`ghcr.io/axonops/axondb-search`). TLS and the OpenSearch security plugin
+are enabled by default. The service ships with a hardcoded default admin
+account:
+
+| Setting   | Value                |
+|-----------|----------------------|
+| Username  | `admin`              |
+| Password  | `MyS3cur3P@ss2025`   |
+| Endpoint  | `https://axondb-search:9200` (in-network) |
+| TLS       | Self-signed, generated on first start |
+
+`axon-server` is wired to the backend via environment variables only
+(`SEARCH_DB_HOSTS`, `SEARCH_DB_USERNAME`, `SEARCH_DB_PASSWORD`,
+`SEARCH_DB_SKIP_VERIFY=true`). No config file is mounted.
+
+To rotate the admin credentials, set `AXONOPS_SEARCH_USER` and
+`AXONOPS_SEARCH_PASSWORD` on the `axondb-search` service and mirror the
+same values into `SEARCH_DB_USERNAME` / `SEARCH_DB_PASSWORD` on
+`axon-server`.
+
+## About AxonOps
+
+[AxonOps](https://axonops.com) is the operational platform for Apache Cassandra
+and Apache Kafka. AxonOps provides monitoring, alerting, backup, repair, and
+configuration management for distributed data infrastructure at scale, helping
+teams run their clusters with confidence in production.
+
+This project is maintained by [AxonOps](https://axonops.com). For support,
+visit [axonops.com/contact](https://axonops.com/contact).
+
+## License
+
+This project is licensed under the Apache License 2.0 — see the
+[LICENSE](LICENSE) file for details.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,23 +1,27 @@
 services:
-  elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.24
+  axondb-search:
+    image: ghcr.io/axonops/axondb-search:3.3.2-1.5.0
     environment:
       - discovery.type=single-node
-      - 'ES_JAVA_OPTS=-Xms256m -Xmx256m'
+      - OPENSEARCH_HEAP_SIZE=512m
     volumes:
-      - elasticsearch:/var/lib/elasticsearch
+      - axondb-search:/var/lib/opensearch
     healthcheck:
-      test: ["CMD", "curl", "-sSf", "127.0.0.1:9200"]
+      test: ["CMD", "/usr/local/bin/healthcheck.sh", "readiness"]
       interval: 10s
       timeout: 5s
-      start_period: 30s
+      retries: 10
+      start_period: 120s
   axon-server:
     depends_on:
-      elasticsearch:
+      axondb-search:
         condition: service_healthy
     image: registry.axonops.com/axonops-public/axonops-docker/axon-server:latest
     environment:
-      - ELASTIC_HOSTS=http://elasticsearch:9200
+      - SEARCH_DB_HOSTS=https://axondb-search:9200
+      - SEARCH_DB_USERNAME=admin
+      - SEARCH_DB_PASSWORD=MyS3cur3P@ss2025
+      - SEARCH_DB_SKIP_VERIFY=true
     healthcheck:
       test: ["CMD", "curl", "-sf", "127.0.0.1:8080"]
       interval: 10s
@@ -135,7 +139,7 @@ services:
       start_period: 60s
 
 volumes:
-  elasticsearch:
+  axondb-search:
   cassandra-0:
   cassandra-1:
   cassandra-2:


### PR DESCRIPTION
## Summary
- Replace `docker.elastic.co/elasticsearch:7.17.24` with `ghcr.io/axonops/axondb-search:3.3.2-1.5.0`.
- Keep TLS and the OpenSearch security plugin enabled with the default admin user (`admin` / `MyS3cur3P@ss2025`).
- Wire `axon-server` to the search backend via env vars only (`SEARCH_DB_HOSTS`, `SEARCH_DB_USERNAME`, `SEARCH_DB_PASSWORD`, `SEARCH_DB_SKIP_VERIFY=true`) — no config file mount.
- Add AxonOps branded header, About AxonOps, and License sections to the README per the `axonops-*` branding spec.
- Document the new search backend, default credentials, and credential rotation in the README.

## Test plan
- [x] `docker compose config --quiet` passes
- [x] `docker compose up -d axondb-search axon-server` brings both services to `healthy`
- [x] `axon-server` logs show it is listening for agents and dashboard without search backend errors
- [ ] Bring the full stack up (`docker compose up -d`) and confirm Cassandra nodes register against AxonOps